### PR TITLE
Fix attempting to load linkfield.css as javascript

### DIFF
--- a/src/LinkField.php
+++ b/src/LinkField.php
@@ -74,7 +74,7 @@ class LinkField extends FormField
      */
     public function Field($properties = [])
     {
-        Requirements::javascript('gorriecoe/silverstripe-linkfield: client/dist/linkfield.css');
+        Requirements::css('gorriecoe/silverstripe-linkfield: client/dist/linkfield.css');
         $field = null;
         $parent = $this->parent;
         $relationship = $parent->{$this->name}();


### PR DESCRIPTION
Wrong requirements usage was triggering a "parsererror" message in the CMS when navigating to a page using the Linkfield.