### PR TITLE
Add ability to configure link model fields per linkfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ By default all link types allowed in the Link model are displayed in the edit fo
 
 The Title field can also be hidden, which is useful if you intend on using the URL for a link but not the user-configured Title.
 
-This configuration can be passed into the constructor, or set later using the `` method.
+This configuration can be passed into the constructor, or set later using the `LinkField::setLinkConfig()` method.
 
 #### Declare only which link types _are_ allowed.
 ```php

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $linkConfig = [
         'URL',
     ],
 ];
-LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+LinkField::create('FieldName', 'Field Title', $this, $linkConfig);
 ```
 
 #### Explicitly declare whether each type of link is allowed or not.
@@ -107,7 +107,7 @@ $linkConfig = [
         'File' => FALSE,
     ],
 ];
-LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+LinkField::create('FieldName', 'Field Title', $this, $linkConfig);
 ```
 
 #### Hide the Title field
@@ -115,12 +115,12 @@ LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
 $linkConfig = [
     'title_display' => false,
 ];
-LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+LinkField::create('FieldName', 'Field Title', $this, $linkConfig);
 ```
 
 #### Setting the configuration later
 ```php
-$linkField = LinkField::create($this, 'FieldName');
+$linkField = LinkField::create('FieldName', 'Field Title', $this);
 $linkConfig = [
     'types' => [
         'SiteTree',

--- a/README.md
+++ b/README.md
@@ -75,6 +75,61 @@ class MyClass extends DataObject
 }
 ```
 
+### Configuration
+
+By default all link types allowed in the Link model are displayed in the edit form, but this can be configured per-field, allowing multiple configurations without requiring multiple otherwise-identical Link model subclasses.
+
+The Title field can also be hidden, which is useful if you intend on using the URL for a link but not the user-configured Title.
+
+This configuration can be passed into the constructor, or set later using the `` method.
+
+#### Declare only which link types _are_ allowed.
+```php
+// Allow only SiteTree and URL types, implicitly allow displaying title field.
+$linkConfig = [
+    'types' => [
+        'SiteTree',
+        'URL',
+    ],
+];
+LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+```
+
+#### Explicitly declare whether each type of link is allowed or not.
+```php
+// Allow only SiteTree and URL types.
+$linkConfig = [
+    'types' => [
+        'SiteTree' => TRUE,
+        'URL' => TRUE,
+        'Email' => FALSE,
+        'Phone' => FALSE,
+        'File' => FALSE,
+    ],
+];
+LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+```
+
+#### Hide the Title field
+```php
+$linkConfig = [
+    'title_display' => false,
+];
+LinkField::create($this, 'FieldName', 'Field Title', $linkConfig);
+```
+
+#### Setting the configuration later
+```php
+$linkField = LinkField::create($this, 'FieldName');
+$linkConfig = [
+    'types' => [
+        'SiteTree',
+        'URL',
+    ],
+];
+$linkField->setLinkConfig($linkConfig);
+```
+
 ## Sort column
 
 By default the LinkField assumes that the sort column is named `Sort`. If you want to use another field name such as `SortOrder`, you can specify it using the `setSortColumn` method like so:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,3 +1,6 @@
 ---
 Name: linkfieldconfig
 ---
+gorriecoe\Link\Models\Link:
+  extensions:
+    - gorriecoe\LinkField\Extensions\LinkExtension

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,5 +1,6 @@
 ---
 Name: linkfieldconfig
+After: "*"
 ---
 gorriecoe\Link\Models\Link:
   extensions:

--- a/src/Extensions/LinkExtension.php
+++ b/src/Extensions/LinkExtension.php
@@ -29,6 +29,16 @@ class LinkExtension extends DataExtension
         parent::updateCMSFields($fields);
     }
 
+    public function onBeforeWrite()
+    {
+        parent::onBeforeWrite();
+
+        // re-set the Title if title fields are not editable.
+        if (!$this->shouldDisplayTitleFields()) {
+            $this->resetTitle();
+        }
+    }
+
     /**
      * Only display the link types as defined by the owner's configuration.
      * @param array $types
@@ -50,5 +60,10 @@ class LinkExtension extends DataExtension
     {
         $linkSpecs = $this->owner->link_requirements;
         return !isset($linkSpecs['title_display']) || $linkSpecs['title_display'];
+    }
+
+    protected function resetTitle()
+    {
+        $this->owner->Title = null;
     }
 }

--- a/src/Extensions/LinkExtension.php
+++ b/src/Extensions/LinkExtension.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace gorriecoe\LinkField\Extensions;
+
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\HiddenField;
+
+/**
+ * Used in conjunction with LinkField, makes the types of Links available configurable.
+ */
+class LinkExtension extends DataExtension
+{
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        // Hide Title field if the config requires it.
+        if (!$this->shouldDisplayTitleFields()) {
+            $fields->replaceField('Title', HiddenField::create('Title'));
+        }
+
+        // Set default Type value.
+        $types = array_keys($this->owner->getTypes());
+        $typeField = $fields->dataFieldByName('Type');
+        if (!in_array($typeField->Value(), $types)) {
+            $typeField->setValue($types[0]);
+        }
+
+        parent::updateCMSFields($fields);
+    }
+
+    /**
+     * Only display the link types as defined by the owner's configuration.
+     * @param array $types
+     * @see \gorriecoe\Link\Models\Link::getTypes
+     */
+    public function updateTypes(&$types)
+    {
+        $linkSpecs = $this->owner->link_requirements;
+        if (!empty($linkSpecs['types'])) {
+            foreach ($types as $type => $typeName) {
+                if (empty($linkSpecs['types'][$type]) && !in_array($type, $linkSpecs['types'], true)) {
+                    unset($types[$type]);
+                }
+            }
+        }
+    }
+
+    protected function shouldDisplayTitleFields()
+    {
+        $linkSpecs = $this->owner->link_requirements;
+        return !isset($linkSpecs['title_display']) || $linkSpecs['title_display'];
+    }
+}

--- a/src/Forms/GridField/GridFieldHasOneDeleteButton.php
+++ b/src/Forms/GridField/GridFieldHasOneDeleteButton.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace gorriecoe\LinkField\Forms\GridField;
+
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\Forms\GridField\GridField_ActionProvider;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use JsonSchema\Exception\ValidationException;
+use SilverStripe\Control\Controller;
+
+class GridFieldHasOneDeleteButton implements GridField_HTMLProvider, GridField_ActionProvider
+{
+
+    /**
+     * Fragment to write the button to
+     */
+    protected $targetFragment;
+
+    /**
+     * GridFieldHasOneUnlinkButton constructor.
+     * @param DataObject $parent
+     * @param string $targetFragment
+     */
+    public function __construct($targetFragment = 'buttons-before-right')
+    {
+        $this->targetFragment = $targetFragment;
+    }
+
+    /**
+     * Get fragment to write the button to
+     */
+    public function getTargetFragment()
+    {
+        return $this->targetFragment;
+    }
+
+    /**
+     * Set fragment to write the button to
+     *
+     * @param string $targetFragment
+     * @return static
+     */
+    public function setTargetFragment($targetFragment)
+    {
+        $this->targetFragment = $targetFragment;
+        return $this;
+    }
+
+    /**
+     * @param GridField $gridField
+     * @return array
+     */
+    public function getActions($gridField)
+    {
+        return ['deleterelation'];
+    }
+
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        if ($actionName !== 'deleterelation') {
+            return;
+        }
+
+        $record = $gridField->getRecord();
+        if (!$record || !$record->exists()) {
+            return;
+        }
+
+        /** @var DataObject|null $item */
+        $item = $gridField->getList()->byID($record->ID);
+        if ($item === null) {
+            return;
+        }
+
+        if (!$item->canDelete()) {
+            throw new ValidationException(
+                _t(__CLASS__ . '.EditPermissionsFailure', 'No delete permissions')
+            );
+        }
+
+        $gridField->setRecord(null);
+        $gridField->getList()->remove($item);
+        $item->delete();
+
+        Controller::curr()->getResponse()->setStatusCode(
+            200,
+            _t(__CLASS__ . '.Deleted', 'Deleted')
+        );
+    }
+
+    public function getHTMLFragments($gridField)
+    {
+        $record = $gridField->getRecord();
+        if (!$record || !$record->exists()) {
+            return [];
+        }
+
+        $field = new GridField_FormAction(
+            $gridField,
+            'gridfield_deleterelation',
+            _t(__CLASS__ . '.Delete', 'Delete'),
+            'deleterelation',
+            'deleterelation'
+        );
+
+        $field->setAttribute('data-icon', 'chain--plus')
+            ->addExtraClass(
+                'align-items-center d-flex btn btn-outline-secondary '
+                    . 'font-icon-trash-bin action_gridfield_deleterelation'
+            );
+
+        return [
+            $this->targetFragment => $field->Field(),
+        ];
+    }
+}

--- a/src/Forms/GridField/GridFieldLinkDetailForm.php
+++ b/src/Forms/GridField/GridFieldLinkDetailForm.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace gorriecoe\LinkField\Forms\GridField;
+
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\ORM\DataObject;
+
+class GridFieldLinkDetailForm extends GridFieldDetailForm
+{
+
+    /**
+     * @var array
+     */
+    protected $linkConfig;
+
+    public function __construct($linkConfig = array(), $name = null, $showPagination = null, $showAdd = null)
+    {
+        parent::__construct($name, $showPagination, $showAdd);
+
+        $this->setLinkConfig($linkConfig);
+    }
+
+    /**
+     * Get the record from the http request.
+     * When creating a new record, see if the HasOneLinkField has already given us a new record instance.
+     *
+     * {@inheritDoc}
+     * @see \SilverStripe\Forms\GridField\GridFieldDetailForm::getRecordFromRequest()
+     */
+    protected function getRecordFromRequest(GridField $gridField, HTTPRequest $request): ?DataObject
+    {
+        /** @var Filterable $dataList */
+        $dataList = $gridField->getList();
+        $id = $request->param('ID');
+        $record = null;
+
+        /** @var DataObject $record */
+        if (is_numeric($id)) {
+            $record = $dataList->byID($id);
+        } else {
+            if ($id == 'new') {
+                $record = $dataList->byID(0);
+            }
+            if (!$record) {
+                $record = Injector::inst()->create($gridField->getModelClass());
+            }
+        }
+        // Set the config on the record if we have one.
+        if ($record) {
+            $record->link_requirements = $this->getLinkConfig();
+        }
+
+        return $record;
+    }
+
+    /**
+     * Set the configuration for this Link relationship.
+     *
+     * @param array $linkConfig
+     * @return $this
+     */
+    public function setLinkConfig($linkConfig)
+    {
+        $this->linkConfig = $linkConfig;
+        return $this;
+    }
+
+    /**
+     * Get the configuration for this Link relationship.
+     *
+     * @return array
+     */
+    public function getLinkConfig()
+    {
+        return $this->linkConfig;
+    }
+}

--- a/src/Forms/GridField/HasOneLinkField.php
+++ b/src/Forms/GridField/HasOneLinkField.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace gorriecoe\LinkField\Forms;
+
+use gorriecoe\LinkField\Forms\GridField\GridFieldHasOneDeleteButton;
+use gorriecoe\LinkField\Forms\GridField\GridFieldLinkDetailForm;
+use SilverShop\HasOneField\GridFieldHasOneButtonRow;
+use SilverShop\HasOneField\GridFieldHasOneEditButton;
+use SilverShop\HasOneField\GridFieldSummaryField;
+use SilverShop\HasOneField\HasOneButtonField;
+use SilverStripe\Core\Convert;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * FormField to add a {@link \gorriecoe\Link\Models\Link} to a has_one relationship.
+ *
+ * This field allows configuration to define which types of link are available, which is passed to it
+ * from the {@link \gorriecoe\LinkField\LinkField}.
+ *
+ * @see \gorriecoe\LinkField\LinkField
+ */
+class HasOneLinkField extends HasOneButtonField
+{
+    public function __construct(
+        DataObject $parent,
+        $relationName,
+        $title = null,
+        $linkConfig = array(),
+        $useAutocompleter = false
+    ) {
+        $config = GridFieldConfig::create()
+            ->addComponent(new GridFieldHasOneButtonRow())
+            ->addComponent(new GridFieldSummaryField($relationName))
+            ->addComponent($detailForm = new GridFieldLinkDetailForm($linkConfig))
+            ->addComponent(new GridFieldHasOneDeleteButton())
+            ->addComponent(new GridFieldHasOneEditButton('buttons-before-right'));
+
+        $detailForm->setShowAdd(false);
+
+        parent::__construct($parent, $relationName, null, $title, $config, $useAutocompleter);
+    }
+
+    /**
+     * Set the configuration for this Link relationship.
+     *
+     * @param array $linkConfig
+     * @return $this
+     */
+    public function setLinkConfig($linkConfig)
+    {
+        $detailForm = $this->getConfig()->getComponentByType(GridFieldLinkDetailForm::class);
+        if ($detailForm) {
+            $detailForm->setLinkConfig($linkConfig);
+        }
+        return $this;
+    }
+
+    /**
+     * Get the configuration for this Link relationship.
+     *
+     * @return array
+     */
+    public function getLinkConfig()
+    {
+        $detailForm = $this->getConfig()->getComponentByType(GridFieldLinkDetailForm::class);
+        if ($detailForm) {
+            return $detailForm->getLinkConfig();
+        }
+        return [];
+    }
+
+    /**
+     * Check that there is a link.
+     *
+     * RequiredFields makes assumptions about what missing values look like
+     * that the underlying implementation does not meet (specifically, a
+     * missing link is not an empty array). That check is hard-coded into
+     * RequiredFields.
+     *
+     * This works around it by checking to see if the field is required, then
+     * checking whether it is empty as part of validate(). Normally, required
+     * fields are checked in a separate check following validation.
+     *
+     * {@inheritdoc}
+     * @see \SilverStripe\Forms\FormField::validate()
+     */
+    public function validate($validator)
+    {
+        $valid = parent::validate($validator);
+        if ($valid) {
+            $result = $this->getRecord()->validate();
+            $valid = $result->isValid();
+            foreach ($result->getMessages() as $message) {
+                $validator->validationError($this->getName(), $message);
+            }
+        }
+        if ($valid && $validator->fieldIsRequired($this->getName()) && !$this->getRecord()->Type) {
+            $valid = false;
+
+            $errorMessage = _t('SilverStripe\\Forms\\Form.FIELDISREQUIRED', '{name} is required', [
+                'name' => strip_tags('"' . ($this->Title() ?: $this->getName()) . '"'),
+            ]);
+
+            $validator->validationError($this->getName(), $errorMessage, 'required');
+        }
+        return $valid;
+    }
+
+    /**
+     * Display GridField with messages.
+     *
+     * GridField renders using a hard-coded table, consequently it cannot
+     * display messages. This will append any messages.
+     *
+     * {@inheritdoc}
+     * @see \SilverStripe\Forms\GridField\GridField::FieldHolder()
+     */
+    public function FieldHolder($properties = array())
+    {
+        $html = parent::FieldHolder();
+        $message = Convert::raw2xml($this->getMessage());
+        if (is_array($message)) {
+            $message = $message['message'];
+        }
+
+        if ($message) {
+            $html .= '<p class="alert ' . $this->getAlertType()
+                . '" role="alert" id="message-' . $this->ID
+                . '">' . $message . '</p>';
+        }
+
+        return $html;
+    }
+}

--- a/src/LinkField.php
+++ b/src/LinkField.php
@@ -3,6 +3,8 @@
 namespace gorriecoe\LinkField;
 
 use gorriecoe\Link\Models\Link;
+use gorriecoe\LinkField\Forms\GridField\GridFieldLinkDetailForm;
+use gorriecoe\LinkField\Forms\HasOneLinkField;
 use SilverStripe\View\Requirements;
 use SilverStripe\Forms\FormField;
 use SilverStripe\Forms\CompositeField;
@@ -14,8 +16,6 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 use SilverStripe\Forms\GridField\GridFieldEditButton;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
-use SilverStripe\Forms\GridField\GridFieldDetailForm;
-use SilverStripe\Control\HasRequestHandler;
 use SilverStripe\Control\HTTPRequest;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use SilverShop\HasOneField\HasOneButtonField;
@@ -59,13 +59,14 @@ class LinkField extends FormField
      */
     private static $sort_column = 'Sort';
 
-    public function __construct($name, $title, $parent)
+    public function __construct($name, $title, $parent, $linkConfig = array())
     {
         parent::__construct($name, $title, null);
 
         $this->name = $name;
         $this->title = $title;
         $this->parent = $parent;
+        $this->linkConfig = $linkConfig;
         if ($this->isOneOrMany() == 'one') {
             $this->record = $parent->{$name}();
         }
@@ -172,11 +173,11 @@ class LinkField extends FormField
      */
     public function getHasOneField()
     {
-        $field = HasOneButtonField::create(
+        $field = HasOneLinkField::create(
             $this->parent,
             $this->name,
-            null,
-            $this->title
+            $this->title,
+            $this->linkConfig
         )
         ->setForm($this->Form)
         ->addExtraClass('linkfield__button');
@@ -194,7 +195,7 @@ class LinkField extends FormField
         $config = GridFieldConfig::create()
             ->addComponent(new GridFieldButtonRow('before'))
             ->addComponent(new GridFieldAddNewButton('buttons-before-left'))
-            ->addComponent(new GridFieldDetailForm())
+            ->addComponent(new GridFieldLinkDetailForm($this->getLinkConfig()))
             ->addComponent(new GridFieldDataColumns())
             ->addComponent(new GridFieldOrderableRows($this->getSortColumn()))
             ->addComponent(new GridFieldEditButton())
@@ -238,5 +239,31 @@ class LinkField extends FormField
             return $this->sortColumn;
         }
         return $this->config()->get('sort_column');
+    }
+
+    /**
+     * Set the configuration for this Link relationship.
+     * @param array $linkConfig
+     * @return $this
+     */
+    public function setLinkConfig($linkConfig)
+    {
+        $this->linkConfig = $linkConfig;
+        return $this;
+    }
+
+    /**
+     * Get the configuration for this Link relationship.
+     * @return array
+     */
+    public function getLinkConfig()
+    {
+        return $this->linkConfig;
+    }
+
+    public function validate($validator)
+    {
+        $valid = $this->Field()->validate($validator);
+        return $valid;
     }
 }


### PR DESCRIPTION
Addresses #1
Fixes #23 and #21
Also allows validating against a has_one Link using the RequiredFields validator.

The assumption at this stage is that for #23 you'll want to go with option 2 "Replace the unlink button on the has_one field with a delete button, and remove the option for linking to existing objects." but I can change it if you prefer another option.