### PR TITLE
Allow GridFieldExtensions 4 for Silverstripe 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   "require": {
     "gorriecoe/silverstripe-link": "^1.0",
     "silvershop/silverstripe-hasonefield": "^3.0",
-    "symbiote/silverstripe-gridfieldextensions": "^3.1"
+    "symbiote/silverstripe-gridfieldextensions": "^3.1 || ^4.0"
   },
   "extra": {
     "installer-name": "linkfield",


### PR DESCRIPTION
Tested in Silverstripe 5.0.0-beta1 and all seems to work well