### PR TITLE
Bug fix: PHP 8.2 support - fixed creation of dynamic property

### DIFF
--- a/src/LinkField.php
+++ b/src/LinkField.php
@@ -38,6 +38,11 @@ class LinkField extends FormField
     protected $title;
 
     /**
+     * @var array $linkConfig
+     */
+    protected $linkConfig;
+
+    /**
      * @var DataObject $parent
      */
     protected $parent;


### PR DESCRIPTION
Added class variable for `$linkConfig`  in `src/LinkField.php` as it throws a deprecation warning on PHP 8.2