### PR TITLE
Require hasonefield 3 || 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "homepage": "http://github.com/gorriecoe/silverstripe-linkfield",
   "require": {
     "gorriecoe/silverstripe-link": "^1.0",
-    "silvershop/silverstripe-hasonefield": "^3.0",
+    "silvershop/silverstripe-hasonefield": "^3.0 || ^4.0",
     "symbiote/silverstripe-gridfieldextensions": "^3.1 || ^4.0"
   },
   "extra": {


### PR DESCRIPTION
hasonefield has a new major version 4, which is SS5 compatible, while version 3 is no longer compatible.